### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,6 @@ export default postcss.plugin(pkg.name, (options) => {
   return (css, result) => {
     const adaptiveIns = new Adaptive(options)
     const output = adaptiveIns.parse(css.toString())
-    result.root = postcss.parse(output)
+    result.root = postcss.parse(output,{from: css.source.input.file})
   }
 })


### PR DESCRIPTION
修复后继插件无法找到 来源文件路径，如：postcss-sprites